### PR TITLE
Fix paint demo's default brush color

### DIFF
--- a/paint/index.html
+++ b/paint/index.html
@@ -36,7 +36,7 @@
 
 <style type="text/css">
   :root {
-    --brush-color: var(--paint-color);
+    --brush-color: var(--paint);
   }
 
   .paint-api {


### PR DESCRIPTION
Looks like the variable name changed from `--paint-color` to `--paint` at some point.